### PR TITLE
Fix for MacOS Catalina loading of system libraries

### DIFF
--- a/fsevent.lisp
+++ b/fsevent.lisp
@@ -12,11 +12,8 @@
   (:report (lambda (c s) (format s "The call ~@[to~%  ~a~%~]failed.~@[~%  ~a~]"
                                  (function-name c) (message c)))))
 
-(cffi:define-foreign-library corefoundation
-  (T (:framework "CoreFoundation")))
-
-(cffi:define-foreign-library coreservices
-  (T (:framework "CoreServices")))
+(cffi:load-foreign-library "/System/Library/Frameworks/CoreFoundation.framework/Versions/Current/CoreFoundation")
+(cffi:load-foreign-library "/System/Library/Frameworks/CoreServices.framework/Versions/Current/CoreServices")
 
 (cffi:defctype size #+64-bit :uint64 #-64-bit :uint32)
 
@@ -178,8 +175,6 @@
 
 (define-implementation init (&key)
   (unless (boundp '*last-id*)
-    (cffi:use-foreign-library corefoundation)
-    (cffi:use-foreign-library coreservices)
     (setf *last-id* now-id)))
 
 (define-implementation shutdown ()


### PR DESCRIPTION
Loading CoreFoundation and CoreServices on MacOS Catalina wasn't working the old way.
But it does work if you specify the full path.

I'm not sure however if this new fix will also work on older versions of MacOS and can't test it myself, so feel free to ignore the PR.