### PR TITLE
Add support for FreeBSD

### DIFF
--- a/README.mess
+++ b/README.mess
@@ -29,3 +29,4 @@ The following platforms are supported:
 - Linux (inotify)
 - Windows
 - macOS (fsevent)
+- FreeBSD (via libinotify package or devel/libinotify port)

--- a/file-notify.asd
+++ b/file-notify.asd
@@ -11,7 +11,7 @@
   :defsystem-depends-on (:trivial-features)
   :components ((:file "package")
                (:file "protocol")
-               (:file "inotify" :if-feature :linux)
+               (:file "inotify" :if-feature (:or :linux :freebsd))
                (:file "windows" :if-feature :windows)
                (:file "fsevent" :if-feature :darwin)
                (:file "documentation"))


### PR DESCRIPTION
FreeBSD has `devel/libinotify` port which provides a compatibility layer with inotify from Linux. This PR makes it possible to use this library on FreeBSD.